### PR TITLE
Updated README with GitHub repo url

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ C# implementation of Twilio Chat using ASP.NET MVC
 
 1. Clone this repository and `cd` into its directory:
    ```
-   git clone git@github.com:TwilioDevEd/twiliochat-csharp.git
+   git clone https://github.com/TwilioDevEd/twiliochat-csharp.git
    cd twiliochat-csharp
    ```
 


### PR DESCRIPTION
By just following the README and using following command
```
git clone git@github.com:TwilioDevEd/twiliochat-csharp.git
```
gives this error on Mac:

```
The authenticity of host 'github.com (140.82.118.3)' can't be established.
RSA key fingerprint is SHA256:nThbg6kXUpJWGl7E1IGOCspRomTxdCARLviKw6E5SY8.
Are you sure you want to continue connecting (yes/no)? yes
Warning: Permanently added 'github.com,140.82.118.3' (RSA) to the list of known hosts.
git@github.com: Permission denied (publickey).
fatal: Could not read from remote repository.
```

I think it is usually a better practice to use the repo `HTTPS` url.
```
https://github.com/TwilioDevEd/twiliochat-csharp.git
```

